### PR TITLE
fix cmake command to work with current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Boost will be installed with make script
 
 Build Project
 ```bash
-cmake -G "Unix Makefiles"
+cmake -G "Unix Makefiles" .
 make
 python PythonCraft.py
 ```


### PR DESCRIPTION
replaced `cmake -G "Unix Makefiles"` with `cmake -G "Unix Makefiles" .` to fix #2.